### PR TITLE
Traces can have more than 10 fields

### DIFF
--- a/index.html
+++ b/index.html
@@ -117,7 +117,7 @@ $(function(){
         fields = line.split('\t');
         if (fields.length > 10) {
           call = new Call();
-          call.setStart(fields.slice(0, 9));
+          call.setStart(fields.slice(0, 10));
           mode = MATCHING;
           matchPrefix = call.level + '\t' + call.functionNumber + '\t1\t';
           matchPrefixLength = matchPrefix.length;

--- a/index.html
+++ b/index.html
@@ -115,9 +115,9 @@ $(function(){
       if (mode === SEEKING) {
 
         fields = line.split('\t');
-        if (fields.length === 10) {
+        if (fields.length > 10) {
           call = new Call();
-          call.setStart(fields);
+          call.setStart(fields.slice(0, 9));
           mode = MATCHING;
           matchPrefix = call.level + '\t' + call.functionNumber + '\t1\t';
           matchPrefixLength = matchPrefix.length;


### PR DESCRIPTION
The 11th field can be a count of additional parameters, starting from
the 12th field onwards. We should throw away these additional
parameters.

https://xdebug.org/docs/all_settings#trace_format